### PR TITLE
Upgrade to Hibernate ORM 5.3 and JPA 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Hibernate ORM 5 as Java 9 automatic modules
 
-A simple test bed for using Hibernate ORM 5 as (automatic) JPMS modules.
+A simple test bed for using Hibernate ORM 5.3 as (automatic) JPMS modules.
+
 Some things noteworthy:
 
 * Almost all dependencies are used as automatic modules, with the exception of `java.transaction` and `java.persistence`;
 * The JDK's `java.transaction` module is upgraded with _org.jboss.spec.javax.transaction:jboss-transaction-api\_1.2\_spec:2.0.0.Alpha1_, which adds all JTA types (with the exception of the XA package conflicting with the _java.sql_ module)
-* _hibernate-jpa-2.1-api-1.0.0.Final.jar_ can't be used as an automatic module as the naming algorithm stumples upon the "2.1" within the JAR name; so instead ModiTect (https://github.com/moditect/moditect/) is used to convert the JPA API JAR into an explicit JPMS module
+* _javax.persistence-api-2.2.jar_ can't be used as an automatic module as the it needs a `uses javax.persistence.spi.PersistenceProvider` clause in its module definition; so instead ModiTect (https://github.com/moditect/moditect/) is used to convert the JPA API JAR into an explicit JPMS module and we add the missing directive.
 
 All modules are gathered in _target/modules_, a simple test is run using the _maven-exec-plugin_ based on this module path.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <version.com.h2database>1.4.196</version.com.h2database>
         <version.junit>4.12</version.junit>
-        <version.org.hibernate>5.2.12.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.0.Final</version.org.hibernate>
         <version.org.log4j>1.2.17</version.org.log4j>
         <modules.dir>${project.build.directory}/modules</modules.dir>
     </properties>
@@ -18,14 +18,10 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <!-- Module: java.transaction -->
                 <groupId>org.jboss.spec.javax.transaction</groupId>
                 <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                 <version>2.0.0.Alpha1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.javassist</groupId>
-                <artifactId>javassist</artifactId>
-                <version>3.22.0-GA</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -128,7 +124,7 @@
                                 <artifactItem>
                                     <groupId>net.bytebuddy</groupId>
                                     <artifactId>byte-buddy</artifactId>
-                                    <version>1.7.9</version>
+                                    <version>1.8.0</version>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -149,8 +145,9 @@
                             <modules>
                                 <module>
                                     <artifact>
-                                        <groupId>org.hibernate.javax.persistence</groupId>
-                                        <artifactId>hibernate-jpa-2.1-api</artifactId>
+                                        <groupId>javax.persistence</groupId>
+                                        <artifactId>javax.persistence-api</artifactId>
+                                        <version>2.2</version>
                                     </artifact>
                                     <moduleInfo>
                                         <name>java.persistence</name>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 module com.example {
     requires java.persistence;
-    requires hibernate.core;
-    opens com.example to hibernate.core;
+    requires org.hibernate.orm.core;
+    opens com.example to org.hibernate.orm.core;
 }


### PR DESCRIPTION

A little upgrade. I think it's worth applying as the module names have been defined now, and we use the standard JPA API.